### PR TITLE
Remove a bug that was fixed by a gem bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 We've been working on a side project – a to-do list app that students might end
 up using to keep track of things they need to do during their application
 process. We sent it over for testing and the test team emailed back with these
-four bugs that they found (below).
+three bugs that they found (below).
 
 We were hoping you could take a couple of hours (NOTE: it's up to you, but we're
 not expecting this to take up too much of your time) to fix as many of these as
@@ -15,20 +15,16 @@ From: Test Team <test@bridge-u.example>
 To: You <you@bridge-u.example>
 Subject: Bugs!
 
-1. The flash messages (like "Item added" and "List deleted") appear right at the
-   top of the page, but they should be in the main part of the page, just under
-   the navigation bar.
-
-2. I love that you can click "I've döne it!" to mark a todo item as complete,
+1. I love that you can click "I've döne it!" to mark a todo item as complete,
    but after I click it, it shows the item twice - that's a mistake. Instead
    when I click "I've döne it!" I should just see the item crossed out, and the
    link should disappear
 
-3. The page that shows all my lists has an icon telling me how many items are in
+2. The page that shows all my lists has an icon telling me how many items are in
    the list. It should actually tell me how many items are *uncompleted* in the
    list.
 
-4. When I log in, I can see all the lists belonging to other users. That
+3. When I log in, I can see all the lists belonging to other users. That
    seems like a big security risk.
 ```
 


### PR DESCRIPTION
Newer versions of Rails fix the `concat` bug that led to the behaviour we were introducing in the todu app.